### PR TITLE
Add developer documentation (REFERENCE.md and GUIDE.md)

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -346,6 +346,183 @@ function MyButton({ id }: { id: string }) {
 }
 ```
 
+---
+
+## Working with Frontend TypeScript, TSX, and SCSS
+
+### `.ts` vs `.tsx` — what's the difference?
+
+TypeScript comes in two flavors in this project:
+
+- **`.ts`** — plain TypeScript. Logic, utilities, hooks, types. No JSX allowed.
+- **`.tsx`** — TypeScript with JSX support. Required any time you write angle-bracket syntax like `<Button />` or `<div>`.
+
+The rule of thumb: if a file contains any UI markup, it must be `.tsx`. Everything else should be `.ts`.
+
+> **Vite / Fast Refresh constraint:** Vite's React plugin uses React Fast Refresh for hot-module replacement during development. Fast Refresh works best when each `.tsx` file exports *only* React components (functions whose names start with a capital letter and return JSX). If you mix component exports with non-component exports (plain functions, constants, classes) in the same `.tsx` file, you'll see a warning and HMR may fall back to a full page reload. To avoid this, put utility functions and hooks in a sibling `.ts` file and import them into your `.tsx` component file.
+
+---
+
+### What is a JSX component?
+
+A React component is just a TypeScript function that:
+
+1. Takes a single `props` object as its argument (documented with an `interface`)
+2. Returns something React can render — in this codebase that return type is always `ReactNode`
+
+```tsx
+import { ReactNode } from "react";
+
+interface GreetingProps {
+    name: string;
+    /** Optional subtitle text shown below the name */
+    subtitle?: string;
+}
+
+export function Greeting({ name, subtitle }: GreetingProps): ReactNode {
+    return (
+        <div>
+            <h1>Hello, {name}!</h1>
+            {subtitle && <p>{subtitle}</p>}
+        </div>
+    );
+}
+```
+
+The angle-bracket syntax inside the `return` is JSX — it looks like HTML but it's actually TypeScript. `{name}` escapes back into TypeScript to embed a value. `{subtitle && <p>...</p>}` is a common pattern for conditional rendering: if `subtitle` is falsy, nothing renders.
+
+The function name must start with a **capital letter** — that's how React distinguishes components (`<Greeting />`) from HTML elements (`<div>`).
+
+---
+
+### Factoring out components — keeping things composable
+
+When a component gets long or has a distinct piece of UI that appears in multiple places, extract it into its own function. The goal is that each component does one clear thing and composes well with others.
+
+```tsx
+// Before: one big component
+function InsertableCard({ item }: { item: InsertableOut }): ReactNode {
+    return (
+        <div>
+            <img src={item.thumbnailUrls.tiny} />
+            <span>{item.name}</span>
+            <button onClick={...}>Insert</button>
+            <button onClick={...}>Favorite</button>
+        </div>
+    );
+}
+
+// After: factored into focused sub-components
+function CardThumbnail({ url }: { url: string }): ReactNode {
+    return <img src={url} />;
+}
+
+function CardActions({ item }: { item: InsertableOut }): ReactNode {
+    return (
+        <>
+            <button onClick={...}>Insert</button>
+            <button onClick={...}>Favorite</button>
+        </>
+    );
+}
+
+function InsertableCard({ item }: { item: InsertableOut }): ReactNode {
+    return (
+        <div>
+            <CardThumbnail url={item.thumbnailUrls.tiny} />
+            <span>{item.name}</span>
+            <CardActions item={item} />
+        </div>
+    );
+}
+```
+
+A few guidelines:
+- If you find yourself passing the same prop through multiple layers just so a deeply-nested component can use it, consider splitting the file or restructuring so the data is closer to where it's used.
+- Sub-components that are only used inside one parent file don't need to be exported — keep them unexported (no `export` keyword) so it's clear they're internal.
+- Sub-components that appear in more than one file belong in a shared file in the relevant feature directory.
+
+---
+
+### What is a hook?
+
+A **hook** is a special function whose name starts with `use`. Hooks let you "hook into" React features — state, side effects, context — from inside a function component. You can only call hooks at the **top level** of a component or another hook (never inside loops, conditions, or nested functions).
+
+React's built-in hooks you'll encounter in this codebase:
+
+| Hook | What it does |
+|------|-------------|
+| `useState` | Stores a piece of state; re-renders the component when it changes |
+| `useRef` | Holds a mutable value that does **not** trigger a re-render |
+| `useEffect` | Runs a side effect (e.g. set up a listener) after render |
+| `useSyncExternalStore` | Subscribes a component to an external store (used for `localStorage` state in `ui-state.ts`) |
+
+For the full rules and explanation see the [official React docs on hooks](https://react.dev/reference/rules/rules-of-hooks).
+
+**The rules of hooks (never break these):**
+
+1. Only call hooks at the top level of a function — not inside `if`, `for`, or nested callbacks.
+2. Only call hooks from React components or other hooks — never from plain utility functions.
+
+---
+
+### Custom hooks
+
+A custom hook is just a regular TypeScript function that starts with `use` and calls other hooks inside. You write them to extract repeated stateful logic out of components so it can be shared and tested independently.
+
+Example from this codebase — `useUiState()` in `src/frontend/api-utils/ui-state.ts`:
+
+```ts
+// In ui-state.ts (a .ts file — no JSX, so no .tsx needed)
+export function useUiState(): [UiState, SetUiState] {
+    const reactUiState = useSyncExternalStore(subscribeToUiState, getUiState);
+    return [reactUiState, updateUiState];
+}
+
+// In a component:
+function SearchBar(): ReactNode {
+    const [uiState, setUiState] = useUiState();
+    return (
+        <input
+            value={uiState.searchQuery}
+            onChange={(e) => setUiState({ searchQuery: e.target.value })}
+        />
+    );
+}
+```
+
+The hook hides the `useSyncExternalStore` complexity so every component that needs UI state just calls `useUiState()`.
+
+When to write a custom hook vs. a plain function:
+- If your logic calls any React hook (`useState`, `useEffect`, etc.), it **must** be a hook (name starts with `use`, only called from components/hooks).
+- If your logic is pure computation with no hooks inside, make it a plain function.
+
+---
+
+### SCSS in this project
+
+SCSS (Sassy CSS) is a superset of CSS that adds variables, nesting, and other features. In this project it's used very sparingly — almost all styling comes from **Mantine's component system** and its CSS custom properties.
+
+The only SCSS file is `src/frontend/main.scss`, imported once in `main.tsx`. It contains:
+
+- `@layer mantine;` — declares the Mantine cascade layer. This is required at the top so that any global CSS you write outside of a layer wins over Mantine's defaults. Don't remove it.
+- Global resets (like disabling text selection across the app)
+- The `.interactive` utility class, which applies a pointer cursor and the standard Mantine hover background
+
+**Mantine CSS variables** are the right way to match the app's visual style in custom CSS:
+
+```scss
+.my-element {
+    background-color: var(--mantine-color-default-hover);
+    color: var(--mantine-color-text);
+    border-radius: var(--mantine-radius-sm);
+}
+```
+
+Prefer Mantine component props (`c=`, `bg=`, `p=`, `radius=`) over adding new SCSS when possible — Mantine props are theme-aware and respond to light/dark mode automatically. Add to `main.scss` only for truly global styles or utility classes that Mantine doesn't cover.
+
+---
+
 ## The `apiGet` / `apiPost` / `apiDelete` Helpers
 
 These are thin wrappers around `fetch` defined in `src/frontend/api-utils/api.ts`. They:

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -1,0 +1,427 @@
+# FRCDesignApp — Developer Guide
+
+Step-by-step recipes for common development tasks. This guide assumes you've read [REFERENCE.md](./REFERENCE.md) and understand the overall system.
+
+---
+
+## Using the Onshape API Explorer (Glassworks)
+
+Before writing any code that talks to Onshape, start with **Glassworks** — Onshape's interactive API browser. It lets you explore every available endpoint, understand what parameters it accepts, send live requests, and inspect real responses. Think of it as a Postman-style tool built into Onshape.
+
+**URL:** `https://cad.onshape.com/glassworks/explorer`
+
+### How to use it
+
+1. **Open Glassworks** in your browser. You'll see a list of API categories on the left (Documents, Assemblies, PartStudios, etc.).
+2. **Authenticate:** Click the green **Authorize** button at the top of the page. Log in with your Onshape account. This lets Glassworks make real API calls on your behalf.
+3. **Find your endpoint:** Browse the categories or use the search bar. Each endpoint shows its HTTP method (GET, POST, DELETE), path, and a description.
+4. **Try it out:** Click on an endpoint, then click **Try it out**. Fill in any required parameters (you can get document/workspace/element IDs from the URL of an Onshape document), then click **Execute**.
+5. **Inspect the response:** Glassworks shows the full JSON response, the HTTP status code, and the request URL. This is the ground truth for what you'll get when you call the same endpoint from code.
+
+**Tip:** The response shape you see in Glassworks is exactly what you'll get from `client.get(...)` in the backend. Use it to figure out what fields exist so you can type them correctly.
+
+---
+
+## Understanding Onshape Paths
+
+This is the most important concept to understand before adding any Onshape API integration.
+
+### How Onshape organizes content
+
+Everything in Onshape is nested: a **Document** contains one or more **Workspaces** (or Versions, or Microversions), and each Workspace contains **Elements** (tabs — Part Studios, Assemblies, Feature Studios, etc.).
+
+Each level has a unique string ID:
+- `documentId` — identifies the document
+- `instanceId` — identifies the workspace (or version, or microversion) within that document
+- `instanceType` — `"w"` for workspace, `"v"` for version, `"m"` for microversion
+- `elementId` — identifies a specific tab within the instance
+
+### Path types in the codebase
+
+These are defined in `src/shared/onshape-path.ts`:
+
+```ts
+// Just a document
+interface DocumentPath {
+    documentId: string;
+}
+
+// A document + a specific workspace/version/microversion
+interface InstancePath extends DocumentPath {
+    instanceId: string;
+    instanceType: "w" | "v" | "m";
+}
+
+// A document + workspace + a specific element (tab)
+interface ElementPath extends InstancePath {
+    elementId: string;
+}
+```
+
+You'll pass these around everywhere. When you need to call an Onshape endpoint, build the right path object and hand it to `apiPath()`.
+
+### How Onshape REST URLs are structured
+
+Onshape REST paths look like:
+
+```
+/documents/d/{documentId}/w/{workspaceId}/e/{elementId}/assemblies
+```
+
+The pattern is always: service → `/d/` → documentId → `/w/` or `/v/` or `/m/` → instanceId → `/e/` → elementId → endpoint action.
+
+### `apiPath()` — building URLs
+
+The `apiPath()` function in `src/backend/onshape-api/api-path.ts` assembles these URLs for you. You give it the service name, a path object, a serializer, and any options:
+
+```ts
+import { apiPath } from "../api-path";
+import { toInstanceApiPath, toElementApiPath } from "../../../shared/onshape-path";
+
+// Produces: /assemblies/d/{did}/w/{wid}/e/{eid}/features
+apiPath("assemblies", elementPath, toElementApiPath, { endRoute: "features" })
+
+// Produces: /documents/d/{did}/w/{wid}/elements
+apiPath("documents", instancePath, toInstanceApiPath, { endRoute: "elements" })
+```
+
+The serializer functions (`toDocumentApiPath`, `toInstanceApiPath`, `toElementApiPath`) are all defined in `src/shared/onshape-path.ts` and convert a path object into its URL segment string.
+
+---
+
+## Calling the Onshape API
+
+All Onshape API calls go through one of two classes defined in `src/backend/onshape-api/onshape-api.ts`:
+
+**`OAuthApi`** — Use this for requests made on behalf of a logged-in user. It adds the user's OAuth access token as a `Bearer` header. If the token has expired, it automatically refreshes it and retries. This is the class you'll almost always use.
+
+**`KeyApi`** — Use this for server-to-server requests that don't need a user session (e.g., background jobs that use a static API key). It signs requests with HMAC-SHA256.
+
+Both expose the same methods: `.get()`, `.post()`, `.delete()`, `.getImage()`, etc.
+
+In a route handler, you get an `OAuthApi` instance like this:
+
+```ts
+const onshapeApi = await c.var.getOnshapeApi();
+```
+
+Then pass it to any function in `src/backend/onshape-api/endpoints/`:
+
+```ts
+import { getDocumentElements } from "../onshape-api/endpoints/documents";
+
+const elements = await getDocumentElements(onshapeApi, instancePath);
+```
+
+**Before writing a new wrapper function, check if it already exists** in one of the files under `src/backend/onshape-api/endpoints/`:
+
+| File | Wraps |
+|---|---|
+| `documents.ts` | Document metadata, workspaces, elements, references |
+| `assemblies.ts` | Assembly structure, adding elements, adding features, transforms |
+| `part-studios.ts` | Part Studio features |
+| `feature-studios.ts` | Feature Studio code (pull/push) |
+| `configurations.ts` | Configuration definitions and encoding |
+| `thumbnails.ts` | Element thumbnail images |
+| `users.ts` | User info, session ping |
+| `permissions.ts` | Permission checks |
+| `metadata.ts` | Element/part metadata |
+| `versions.ts` | Version listing |
+| `settings.ts` | Document settings |
+
+---
+
+## Adding a New Onshape API Wrapper
+
+Use this when you need to call an Onshape endpoint that doesn't have a wrapper yet.
+
+### 1. Find the endpoint in Glassworks
+
+Go to `https://cad.onshape.com/glassworks/explorer`, find the endpoint, try it with a real document, and note the path structure and response shape.
+
+### 2. Add a wrapper function
+
+Find the right file in `src/backend/onshape-api/endpoints/` (or create a new one if the category is new). Add a typed function:
+
+```ts
+import { OnshapeApi } from "../onshape-api";
+import { ElementPath, toElementApiPath } from "../../../shared/onshape-path";
+import { apiPath } from "../api-path";
+
+/** Fetches the BOM for an assembly element. */
+export function getAssemblyBom(
+    client: OnshapeApi,
+    elementPath: ElementPath
+): Promise<any> {
+    return client.get(
+        apiPath("assemblies", elementPath, toElementApiPath, {
+            endRoute: "bom"
+        })
+    );
+}
+```
+
+A few notes:
+- Return type `Promise<any>` is fine to start. Once you know the response shape, define an interface and use that instead.
+- Use `apiPath()` to build the URL rather than constructing strings manually — it handles encoding and prefix logic for you.
+- For POST calls, pass `{ body: { ... } }` as the second argument to `client.post()`.
+
+### 3. Call it from a backend route
+
+Import your new function in the appropriate route file and call it inside a handler (see the next section).
+
+---
+
+## Adding a New Backend Route
+
+Use this when you need to expose new functionality to the frontend via a new API endpoint.
+
+### 1. Add the handler to a routes file
+
+Open the relevant file in `src/backend/routes/` (or create a new one if the functionality is in a new area). Each file creates a Hono sub-app and registers handlers on it:
+
+```ts
+import { getApp, libraryRoute, getLibraryParam } from "../app";
+import { getDb } from "../db";
+// ... other imports
+
+export const myRoutes = getApp();
+
+/** GET /api/my-thing/library/:libraryId */
+myRoutes.get("/my-thing" + libraryRoute(), async (c) => {
+    const libraryId = getLibraryParam(c);
+    const db = getDb(c.env.DB);
+    const onshapeApi = await c.var.getOnshapeApi();
+
+    // ... do your work here
+
+    return c.json({ result: "..." });
+});
+```
+
+**Route param helpers** (defined in `src/backend/app.ts`):
+- `libraryRoute()` — returns `"/library/:libraryId"`. Use `getLibraryParam(c)` to read it.
+- `insertableRoute()` — returns `"/insertable/:insertableId"`. Use `getInsertableParam(c)`.
+- `groupRoute()` — returns `"/group/:groupId"`. Use `getGroupParam(c)`.
+
+**Protecting routes:** Wrap the handler with middleware if it requires elevated access:
+
+```ts
+import { requireEditorMiddleware } from "../access-level-utils";
+
+myRoutes.post("/my-admin-action", requireEditorMiddleware, async (c) => {
+    // only editors and admins reach here
+});
+```
+
+### 2. Register the route group in `create-app.ts`
+
+Open `src/backend/create-app.ts`, import your new routes, and mount them:
+
+```ts
+import { myRoutes } from "./routes/my-routes";
+
+// Inside createApp():
+app.route("/api", myRoutes);
+```
+
+### 3. Define the response type in shared
+
+If the frontend needs to consume this endpoint, define a TypeScript interface for the response in `src/shared/api-models.ts` so both sides agree on the shape.
+
+---
+
+## Modifying the Database Schema
+
+The schema is the source of truth for what's stored in D1. Drizzle ORM reads it to generate both TypeScript types and SQL migrations.
+
+### 1. Edit the schema
+
+Open `src/shared/schema.ts`. Tables are defined using Drizzle's SQLite helpers:
+
+```ts
+import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
+
+export const myTable = sqliteTable("my_table", {
+    id: text("id").primaryKey(),
+    name: text("name").notNull(),
+    count: integer("count").default(0)
+});
+```
+
+Every column you add here becomes available in TypeScript automatically — Drizzle infers the types.
+
+### 2. Generate the migration
+
+```bash
+npx drizzle-kit generate
+```
+
+This creates a new `.sql` file in `drizzle/`. Commit this file — it's how the schema gets applied to production D1.
+
+### 3. Apply it locally
+
+```bash
+npx wrangler d1 migrations apply DB --local
+```
+
+This runs all pending migrations against your local D1 database (used by `npx wrangler dev`).
+
+### 4. Update API response types if needed
+
+If the new data needs to be returned to the frontend, update the relevant interface in `src/shared/api-models.ts` and modify the query in `src/backend/library-data.ts` (if it's part of the main library response) or in the appropriate route handler.
+
+---
+
+## Adding a Frontend Route
+
+TanStack Router uses **file-based routing**: the path of a `.tsx` file under `src/frontend/routes/` maps directly to a URL. No manual registration needed.
+
+### 1. Create the route file
+
+Create a `.tsx` file at the right path. For example, to add `/app/settings`:
+
+```
+src/frontend/routes/app/settings.tsx
+```
+
+Inside the file, export a `createFileRoute` call and a default component:
+
+```tsx
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/app/settings")({
+    component: SettingsPage
+});
+
+function SettingsPage() {
+    return <div>Settings go here</div>;
+}
+```
+
+### 2. Let the router regenerate
+
+The next time you run `npm run dev`, TanStack Router's Vite plugin will detect the new file and update `src/frontend/routeTree.gen.ts` automatically. You don't need to touch that file.
+
+### 3. Load data in the route (optional)
+
+If your route needs data from the backend, you have two options:
+
+**Option A — `loader` function (runs before the component renders):**
+
+```tsx
+export const Route = createFileRoute("/app/settings")({
+    loader: () => apiGet("/my-settings"),
+    component: SettingsPage
+});
+
+function SettingsPage() {
+    const data = Route.useLoaderData();
+    return <div>{data.name}</div>;
+}
+```
+
+**Option B — React Query inside the component (runs when the component mounts):**
+
+```tsx
+import { useQuery } from "@tanstack/react-query";
+import { apiGet } from "../../api-utils/api";
+
+function SettingsPage() {
+    const { data, isLoading } = useQuery({
+        queryKey: ["my-settings"],
+        queryFn: () => apiGet("/my-settings")
+    });
+    if (isLoading) return <div>Loading...</div>;
+    return <div>{data.name}</div>;
+}
+```
+
+Use the `loader` approach when you want the data to be ready before the page renders (avoids a loading flash). Use React Query when you want to re-fetch in the background or share the data with other components.
+
+### 4. Navigate to the new route
+
+Use TanStack Router's `<Link>` component for navigation:
+
+```tsx
+import { Link } from "@tanstack/react-router";
+
+<Link to="/app/settings">Go to settings</Link>
+```
+
+---
+
+## Adding a Frontend Data Fetch
+
+If you just need to fetch data inside an existing component (without creating a new route), follow this pattern.
+
+### 1. Define the query in `queries.ts`
+
+Open `src/frontend/queries.ts` and add a query definition:
+
+```ts
+import { queryOptions } from "@tanstack/react-query";
+import { apiGet } from "./api-utils/api";
+
+export function getMyDataQuery(someId: string) {
+    return queryOptions({
+        queryKey: ["my-data", someId],
+        queryFn: () => apiGet("/my-thing/" + someId)
+    });
+}
+```
+
+Keeping query definitions in `queries.ts` means the same query can be used in multiple components and they'll all share the same cache.
+
+### 2. Use it in a component
+
+```tsx
+import { useQuery } from "@tanstack/react-query";
+import { getMyDataQuery } from "../queries";
+
+function MyComponent({ id }: { id: string }) {
+    const { data, isLoading, isError } = useQuery(getMyDataQuery(id));
+
+    if (isLoading) return <div>Loading...</div>;
+    if (isError) return <div>Something went wrong.</div>;
+    return <div>{data.name}</div>;
+}
+```
+
+### Posting data (mutations)
+
+For actions that change data (POST, DELETE), use React Query's `useMutation`:
+
+```tsx
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiPost } from "../api-utils/api";
+
+function MyButton({ id }: { id: string }) {
+    const queryClient = useQueryClient();
+    const mutation = useMutation({
+        mutationFn: () => apiPost("/do-thing", { body: { id } }),
+        onSuccess: () => {
+            // Invalidate any queries whose data may have changed
+            queryClient.invalidateQueries({ queryKey: ["my-data"] });
+        }
+    });
+
+    return (
+        <button onClick={() => mutation.mutate()} disabled={mutation.isPending}>
+            {mutation.isPending ? "Saving..." : "Do Thing"}
+        </button>
+    );
+}
+```
+
+---
+
+## The `apiGet` / `apiPost` / `apiDelete` Helpers
+
+These are thin wrappers around `fetch` defined in `src/frontend/api-utils/api.ts`. They:
+- Automatically prepend `/api` to the path (so you write `"/context-data"` not `"/api/context-data"`)
+- Serialize query parameters via `URLSearchParams`
+- Append a `?v=` cache-busting parameter when `cacheId` is provided
+- Parse the JSON response and throw a typed error if the response is not OK
+
+You don't need to use `fetch` directly in frontend code — always use these helpers.

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -107,6 +107,8 @@ const elements = await getDocumentElements(onshapeApi, instancePath);
 
 Before writing a new wrapper function, check if it already exists in one of the files under `src/backend/onshape-api/endpoints/`.
 
+---
+
 ## Adding a New Backend Route
 
 Use this when you need to expose new functionality to the frontend via a new API endpoint.
@@ -165,6 +167,65 @@ app.route("/api", myRoutes);
 
 If the frontend needs to consume this endpoint, define a TypeScript interface for the response in `src/shared/api-models.ts` so both sides agree on the shape.
 
+---
+
+## Path Params, Query Params, and Request Bodies
+
+HTTP gives you three places to put data in a request. Choosing the right one makes APIs easier to understand and use correctly.
+
+### When to use each
+
+| Type | Where it lives | Use for |
+|------|---------------|---------|
+| **Path param** | Embedded in the URL path: `/api/group/:groupId` | Identifying a specific resource. If removing it would make the URL ambiguous, it's a path param. |
+| **Query param** | After the `?`: `/api/favorites?insertableId=abc` | Options, filters, or secondary identifiers on GET requests. |
+| **Request body** | JSON payload sent with POST/DELETE | Structured data for mutations — things that create or update resources. |
+
+### Frontend: sending params
+
+```ts
+// Path param — embed directly in the URL string
+apiGet("/library-data" + toLibraryPath(libraryId));
+// → GET /api/library-data/library/my-library
+
+// Query param — pass as options.query
+apiPost("/favorites" + toLibraryPath(libraryId), {
+    query: { insertableId: "abc123", id: favoriteId }
+});
+// → POST /api/favorites/library/my-library?insertableId=abc123&id=...
+
+// Request body — pass as options.body
+apiPost("/add-group", {
+    body: { documentId, name }
+});
+// → POST /api/add-group  (JSON body: { "documentId": "...", "name": "..." })
+```
+
+`apiGet`, `apiPost`, and `apiDelete` all accept `options.query` for query params. Only `apiPost` accepts `options.body` — GET and DELETE requests don't carry a body.
+
+### Backend: reading params
+
+```ts
+// Path param — use a helper or c.req.param() directly
+const libraryId = getLibraryParam(c);          // helper from app.ts
+const groupId   = c.req.param("groupId");      // raw Hono API
+
+// Query param
+const insertableId = c.req.query("insertableId");
+
+// Request body
+const { documentId, name } = await c.req.json<{ documentId: string; name: string }>();
+```
+
+### Onshape API: sending params
+
+When calling the Onshape API from the backend, the same concept applies:
+
+- **Path params** are handled by `apiPath()` — the `ElementPath` / `InstancePath` fields become the path segments automatically.
+- **Query params** for Onshape endpoints can be passed through the endpoint wrapper functions in `src/backend/onshape-api/endpoints/`, which append them to the URL returned by `apiPath()`.
+
+---
+
 ## Modifying the Database Schema
 
 The schema is the source of truth for what's stored in D1. Drizzle ORM reads it to generate both TypeScript types and SQL migrations.
@@ -185,13 +246,17 @@ export const myTable = sqliteTable("my_table", {
 
 Every column you add here becomes available in TypeScript automatically — Drizzle infers the types.
 
-### 2. Generate the migration
+### 2. Generate and commit the migration
 
 ```bash
 npx drizzle-kit generate
 ```
 
-This creates a new `.sql` file in `drizzle/`. Commit this file — it's how the schema gets applied to production D1.
+This creates a new `.sql` file in `drizzle/`. A **migration** is a versioned SQL script that describes exactly what changed in the schema (e.g. "add column X to table Y"). Drizzle Kit generates it by comparing your current `schema.ts` against the previously generated state.
+
+Always commit the generated migration file alongside your schema change. The migration is what actually updates the production database on deploy — the TypeScript schema in `schema.ts` drives Drizzle's type inference, but the SQL migration is what Cloudflare D1 applies.
+
+> **Note:** While the app is under active development, migrations may be periodically squashed (merged into a single file) to keep the `drizzle/` directory manageable. If this happens, the local D1 database will need to be reset and re-migrated from scratch.
 
 ### 3. Apply it locally
 
@@ -204,6 +269,8 @@ This runs all pending migrations against your local D1 database (used by `npx wr
 ### 4. Update API response types if needed
 
 If the new data needs to be returned to the frontend, update the relevant interface in `src/shared/api-models.ts` and modify the query in `src/backend/library-data.ts` (if it's part of the main library response) or in the appropriate route handler.
+
+---
 
 ## Adding a Frontend Route
 
@@ -271,14 +338,15 @@ function SettingsPage() {
 
 Use the `loader` approach when you want the data to be ready before the page renders (avoids a loading flash). Use React Query when you want to re-fetch in the background or share the data with other components.
 
-### 4. Navigate to the new route
-
-Use TanStack Router's `<Link>` component for navigation:
+To read URL path parameters (e.g. `$groupId` in `/app/groups/$groupId`) inside a component, use `useParams`:
 
 ```tsx
-import { Link } from "@tanstack/react-router";
+import { useParams } from "@tanstack/react-router";
 
-<Link to="/app/settings">Go to settings</Link>;
+function GroupPage() {
+    const { groupId } = useParams({ from: "/app/groups/$groupId" });
+    // ...
+}
 ```
 
 ---
@@ -322,29 +390,67 @@ function MyComponent({ id }: { id: string }) {
 
 ### Posting data (mutations)
 
-For actions that change data (POST, DELETE), use React Query's `useMutation`:
+For actions that change data (POST, DELETE), use React Query's `useMutation`. Mutations in this codebase follow a consistent pattern with three lifecycle callbacks:
 
 ```tsx
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { apiPost } from "../api-utils/api";
+import { queryClient } from "../query-client";
+import { getQueryUpdater } from "../common/utils";
+import { showSuccessToast } from "../common/notifications";
+import { getAppErrorHandler } from "../api-utils/errors";
+import { useRouter } from "@tanstack/react-router";
 
-function MyButton({ id }: { id: string }) {
-    const queryClient = useQueryClient();
-    const mutation = useMutation({
-        mutationFn: () => apiPost("/do-thing", { body: { id } }),
+function useMyMutation(someId: string) {
+    const router = useRouter();
+    const queryKey = ["my-data", someId];
+
+    return useMutation({
+        mutationFn: () => apiPost("/do-thing", { body: { id: someId } }),
+
+        // onMutate: optimistic update — runs BEFORE the request is sent.
+        // Update the cache immediately so the UI reflects the change instantly.
+        onMutate: async () => {
+            // Cancel any in-flight fetches for this data so they don't land
+            // and overwrite our optimistic update.
+            await queryClient.cancelQueries({ queryKey });
+
+            // Update the cache using Immer's produce() via getQueryUpdater.
+            // Immer lets you mutate the draft directly — no spreading needed.
+            queryClient.setQueryData(
+                queryKey,
+                getQueryUpdater((data: MyData) => {
+                    data.someField = "new value";
+                })
+            );
+
+            // Tell TanStack Router that route loader data may be stale.
+            void router.invalidate();
+        },
+
+        // onError: show a toast if the request fails.
+        onError: getAppErrorHandler("Unexpectedly failed to do thing."),
+
+        // onSuccess: show a success toast if the request succeeds.
         onSuccess: () => {
-            // Invalidate any queries whose data may have changed
-            queryClient.invalidateQueries({ queryKey: ["my-data"] });
+            showSuccessToast("Done!");
+        },
+
+        // onSettled: runs regardless of success or failure.
+        // Invalidate queries to re-sync with the real server state.
+        onSettled: async () => {
+            await queryClient.invalidateQueries({ queryKey });
+            void router.invalidate();
         }
     });
-
-    return (
-        <button onClick={() => mutation.mutate()} disabled={mutation.isPending}>
-            {mutation.isPending ? "Saving..." : "Do Thing"}
-        </button>
-    );
 }
 ```
+
+**`getQueryUpdater` and Immer:** `getQueryUpdater` (from `src/frontend/common/utils.ts`) wraps Immer's `produce()` into a function that React Query's `setQueryData` accepts. Immer lets you write direct mutations on a `draft` copy (e.g. `draft.items.push(x)`) instead of building a new object with spread syntax — this is much cleaner for nested data. The original cache value is never mutated; Immer produces a new immutable result.
+
+**Why cancel queries in `onMutate`?** If a background refetch lands after the optimistic update, it will overwrite the cache with stale data. Canceling outstanding queries for that key prevents this race condition.
+
+**Why invalidate in `onSettled`?** `onSettled` always runs, even on failure. Invalidating triggers a fresh server fetch to confirm the real state — if the optimistic update was wrong (e.g. the server rejected the change), this corrects it.
 
 ---
 
@@ -392,6 +498,34 @@ export function Greeting({ name, subtitle }: GreetingProps): ReactNode {
 The angle-bracket syntax inside the `return` is JSX — it looks like HTML but it's actually TypeScript. `{name}` escapes back into TypeScript to embed a value. `{subtitle && <p>...</p>}` is a common pattern for conditional rendering: if `subtitle` is falsy, nothing renders.
 
 The function name must start with a **capital letter** — that's how React distinguishes components (`<Greeting />`) from HTML elements (`<div>`).
+
+**React components are pure functions.** Their only inputs are props (passed in from the parent) and hooks (called at the top level of the component). React tracks these inputs and skips re-running a component when none of its inputs have changed — this is how React stays fast even with large UIs.
+
+```tsx
+interface CardProps {
+    title: string;
+    onClick: () => void;
+}
+
+function Card({ title, onClick }: CardProps): ReactNode {
+    // Props come from the parent. Hooks are the other input source.
+    const [isHighlighted, setIsHighlighted] = useState(false);
+    const { data } = useQuery(getCardDataQuery(title));
+
+    return (
+        <div
+            onClick={onClick}
+            style={{ background: isHighlighted ? "yellow" : undefined }}
+            onMouseEnter={() => setIsHighlighted(true)}
+            onMouseLeave={() => setIsHighlighted(false)}
+        >
+            {title} — {data?.subtitle}
+        </div>
+    );
+}
+```
+
+Passing `onClick` as a prop (rather than defining behavior inside the component) is the key to composability: the parent decides what happens, the child decides how it looks.
 
 ---
 
@@ -455,7 +589,8 @@ React's built-in hooks you'll encounter in this codebase:
 | `useState` | Stores a piece of state; re-renders the component when it changes |
 | `useRef` | Holds a mutable value that does **not** trigger a re-render |
 | `useEffect` | Runs a side effect (e.g. set up a listener) after render |
-| `useSyncExternalStore` | Subscribes a component to an external store (used for `localStorage` state in `ui-state.ts`) |
+| `useLoaderData` | Reads the data returned by the current route's `loader` or `beforeLoad` function |
+| `useParams` | Reads path parameters from the current URL (e.g. `groupId` in `/app/groups/$groupId`) |
 
 For the full rules and explanation see the [official React docs on hooks](https://react.dev/reference/rules/rules-of-hooks).
 
@@ -463,6 +598,10 @@ For the full rules and explanation see the [official React docs on hooks](https:
 
 1. Only call hooks at the top level of a function — not inside `if`, `for`, or nested callbacks.
 2. Only call hooks from React components or other hooks — never from plain utility functions.
+
+If rule 1 tempts you to call a hook conditionally, the fix is to extract a sub-component and render it conditionally instead — the hook then lives at the top level of the sub-component, which only mounts when needed.
+
+If rule 2 tempts you to call a hook from a utility function, make the utility function itself a hook (prefix it with `use`), and only call it from components or other hooks.
 
 ---
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -2,23 +2,28 @@
 
 Step-by-step recipes for common development tasks. This guide assumes you've read [REFERENCE.md](./REFERENCE.md) and understand the overall system.
 
----
+## Resources
 
-## Using the Onshape API Explorer (Glassworks)
+### Cloudflare Local Explorer
 
-Before writing any code that talks to Onshape, start with **Glassworks** — Onshape's interactive API browser. It lets you explore every available endpoint, understand what parameters it accepts, send live requests, and inspect real responses. Think of it as a Postman-style tool built into Onshape.
+While running `npx wrangler dev`, press **`e`** in the terminal to open the local Cloudflare explorer in your browser. It gives you a live view of your local D1 database, KV namespaces, and R2 buckets — useful for checking that data is being written and read correctly without running manual SQL queries.
 
-You can use Glassworks to see the list of publicly available APIs and test them against Onshape documents.
+### Glassworks (Onshape API Explorer)
+
+Glassworks is Onshape's interactive API browser. Use it to browse available endpoints, read their parameter docs, and test calls before writing any code.
 
 **URL:** `https://cad.onshape.com/glassworks/explorer`
 
-**Tip:** The response shape you see in Glassworks is exactly what you'll get from `client.get(...)` in the backend. Use it to figure out what fields exist so you can type them correctly.
+### Browser Dev Tools (F12)
 
----
+Open with **F12**. Two tabs are most useful during development:
 
-## Understanding Onshape Paths
+- **Console** — shows JavaScript errors, unhandled promise rejections, and any `console.log` output from the frontend. The first place to look when something is broken or silent.
+- **Network** — shows every HTTP request the frontend makes, including requests to `/api/`. Click a request to see its URL, request headers, payload, and the full JSON response. Useful for verifying that the frontend is sending the right data and that the backend is returning what you expect.
 
-This is the most important concept to understand before adding any Onshape API integration.
+## Working with Onshape
+
+This section covers core information important for working with Onshape.
 
 ### How Onshape organizes content
 
@@ -87,9 +92,7 @@ apiPath("documents", instancePath, toInstanceApiPath, { endRoute: "elements" });
 
 The serializer functions (`toDocumentApiPath`, `toInstanceApiPath`, `toElementApiPath`) are all defined in `src/shared/onshape-path.ts` and convert a path object into its URL segment string.
 
----
-
-## Calling the Onshape API
+### Calling the Onshape API
 
 All Onshape API calls go through the `OAuthApi` class, which is a wrapper around the Onshape API which handles authentication. For security reasons, the Onshape API is only available in the backend. The OAuthApi class can be retrieved inside any Hono route handler like this:
 
@@ -107,8 +110,6 @@ const elements = await getDocumentElements(onshapeApi, instancePath);
 
 Before writing a new wrapper function, check if it already exists in one of the files under `src/backend/onshape-api/endpoints/`.
 
----
-
 ## Adding a New Backend Route
 
 Use this when you need to expose new functionality to the frontend via a new API endpoint.
@@ -118,10 +119,6 @@ Use this when you need to expose new functionality to the frontend via a new API
 Open the relevant file in `src/backend/routes/` (or create a new one if the functionality is in a new area). Each file creates a Hono sub-app and registers handlers on it:
 
 ```ts
-import { getApp, libraryRoute, getLibraryParam } from "../app";
-import { getDb } from "../db";
-// ... other imports
-
 export const myRoutes = getApp();
 
 /** GET /api/my-thing/library/:libraryId */
@@ -175,11 +172,11 @@ HTTP gives you three places to put data in a request. Choosing the right one mak
 
 ### When to use each
 
-| Type | Where it lives | Use for |
-|------|---------------|---------|
-| **Path param** | Embedded in the URL path: `/api/group/:groupId` | Identifying a specific resource. If removing it would make the URL ambiguous, it's a path param. |
-| **Query param** | After the `?`: `/api/favorites?insertableId=abc` | Options, filters, or secondary identifiers on GET requests. |
-| **Request body** | JSON payload sent with POST/DELETE | Structured data for mutations — things that create or update resources. |
+| Type             | Where it lives                                   | Use for                                                                                          |
+| ---------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
+| **Path param**   | Embedded in the URL path: `/api/group/:groupId`  | Identifying a specific resource. If removing it would make the URL ambiguous, it's a path param. |
+| **Query param**  | After the `?`: `/api/favorites?insertableId=abc` | Options, filters, or secondary identifiers on GET requests.                                      |
+| **Request body** | JSON payload sent with POST/DELETE               | Structured data for mutations — things that create or update resources.                          |
 
 ### Frontend: sending params
 
@@ -207,14 +204,17 @@ apiPost("/add-group", {
 
 ```ts
 // Path param — use a helper or c.req.param() directly
-const libraryId = getLibraryParam(c);          // helper from app.ts
-const groupId   = c.req.param("groupId");      // raw Hono API
+const libraryId = getLibraryParam(c); // helper from app.ts
+const groupId = c.req.param("groupId"); // raw Hono API
 
 // Query param
 const insertableId = c.req.query("insertableId");
 
 // Request body
-const { documentId, name } = await c.req.json<{ documentId: string; name: string }>();
+const { documentId, name } = await c.req.json<{
+    documentId: string;
+    name: string;
+}>();
 ```
 
 ### Onshape API: sending params
@@ -223,8 +223,6 @@ When calling the Onshape API from the backend, the same concept applies:
 
 - **Path params** are handled by `apiPath()` — the `ElementPath` / `InstancePath` fields become the path segments automatically.
 - **Query params** for Onshape endpoints can be passed through the endpoint wrapper functions in `src/backend/onshape-api/endpoints/`, which append them to the URL returned by `apiPath()`.
-
----
 
 ## Modifying the Database Schema
 
@@ -269,8 +267,6 @@ This runs all pending migrations against your local D1 database (used by `npx wr
 ### 4. Update API response types if needed
 
 If the new data needs to be returned to the frontend, update the relevant interface in `src/shared/api-models.ts` and modify the query in `src/backend/library-data.ts` (if it's part of the main library response) or in the appropriate route handler.
-
----
 
 ## Adding a Frontend Route
 
@@ -349,8 +345,6 @@ function GroupPage() {
 }
 ```
 
----
-
 ## Adding a Frontend Data Fetch
 
 If you just need to fetch data inside an existing component (without creating a new route), follow this pattern.
@@ -360,9 +354,6 @@ If you just need to fetch data inside an existing component (without creating a 
 Open `src/frontend/queries.ts` and add a query definition:
 
 ```ts
-import { queryOptions } from "@tanstack/react-query";
-import { apiGet } from "./api-utils/api";
-
 export function getMyDataQuery(someId: string) {
     return queryOptions({
         queryKey: ["my-data", someId],
@@ -376,9 +367,6 @@ Keeping query definitions in `queries.ts` means the same query can be used in mu
 ### 2. Use it in a component
 
 ```tsx
-import { useQuery } from "@tanstack/react-query";
-import { getMyDataQuery } from "../queries";
-
 function MyComponent({ id }: { id: string }) {
     const { data, isLoading, isError } = useQuery(getMyDataQuery(id));
 
@@ -393,14 +381,6 @@ function MyComponent({ id }: { id: string }) {
 For actions that change data (POST, DELETE), use React Query's `useMutation`. Mutations in this codebase follow a consistent pattern with three lifecycle callbacks:
 
 ```tsx
-import { useMutation } from "@tanstack/react-query";
-import { apiPost } from "../api-utils/api";
-import { queryClient } from "../query-client";
-import { getQueryUpdater } from "../common/utils";
-import { showSuccessToast } from "../common/notifications";
-import { getAppErrorHandler } from "../api-utils/errors";
-import { useRouter } from "@tanstack/react-router";
-
 function useMyMutation(someId: string) {
     const router = useRouter();
     const queryKey = ["my-data", someId];
@@ -446,7 +426,7 @@ function useMyMutation(someId: string) {
 }
 ```
 
-**`getQueryUpdater` and Immer:** `getQueryUpdater` (from `src/frontend/common/utils.ts`) wraps Immer's `produce()` into a function that React Query's `setQueryData` accepts. Immer lets you write direct mutations on a `draft` copy (e.g. `draft.items.push(x)`) instead of building a new object with spread syntax — this is much cleaner for nested data. The original cache value is never mutated; Immer produces a new immutable result.
+`getQueryUpdater` (from `src/frontend/common/utils.ts`) wraps Immer's `produce()` into a function that React Query's `setQueryData` accepts. Immer allows you to mutate query results directly rather than mutating an original cache value, which is much cleaner for nested data.
 
 **Why cancel queries in `onMutate`?** If a background refetch lands after the optimistic update, it will overwrite the cache with stale data. Canceling outstanding queries for that key prevents this race condition.
 
@@ -465,7 +445,7 @@ TypeScript comes in two flavors in this project:
 
 The rule of thumb: if a file contains any UI markup, it must be `.tsx`. Everything else should be `.ts`.
 
-> **Vite / Fast Refresh constraint:** Vite's React plugin uses React Fast Refresh for hot-module replacement during development. Fast Refresh works best when each `.tsx` file exports *only* React components (functions whose names start with a capital letter and return JSX). If you mix component exports with non-component exports (plain functions, constants, classes) in the same `.tsx` file, you'll see a warning and HMR may fall back to a full page reload. To avoid this, put utility functions and hooks in a sibling `.ts` file and import them into your `.tsx` component file.
+> **Vite / Fast Refresh constraint:** Vite's React plugin uses React Fast Refresh for hot-module replacement during development. Fast Refresh works best when each `.tsx` file exports _only_ React components (functions whose names start with a capital letter and return JSX). If you mix component exports with non-component exports (plain functions, constants, classes) in the same `.tsx` file, you'll see a warning and HMR may fall back to a full page reload. To avoid this, put utility functions and hooks in a sibling `.ts` file and import them into your `.tsx` component file.
 
 ---
 
@@ -535,7 +515,11 @@ When a component gets long or has a distinct piece of UI that appears in multipl
 
 ```tsx
 // Before: one big component
-function InsertableCard({ item }: { item: InsertableOut }): ReactNode {
+interface InsertableCardProps {
+    item: InsertableOut;
+}
+
+function InsertableCard({ item }: InsertableCardProps): ReactNode {
     return (
         <div>
             <img src={item.thumbnailUrls.tiny} />
@@ -547,11 +531,19 @@ function InsertableCard({ item }: { item: InsertableOut }): ReactNode {
 }
 
 // After: factored into focused sub-components
-function CardThumbnail({ url }: { url: string }): ReactNode {
+interface CardThumbnailProps {
+    url: string;
+}
+
+function CardThumbnail({ url }: CardThumbnailProps): ReactNode {
     return <img src={url} />;
 }
 
-function CardActions({ item }: { item: InsertableOut }): ReactNode {
+interface CardActionsProps {
+    item: InsertableOut;
+}
+
+function CardActions({ item }: CardActionsProps): ReactNode {
     return (
         <>
             <button onClick={...}>Insert</button>
@@ -560,7 +552,7 @@ function CardActions({ item }: { item: InsertableOut }): ReactNode {
     );
 }
 
-function InsertableCard({ item }: { item: InsertableOut }): ReactNode {
+function InsertableCard({ item }: InsertableCardProps): ReactNode {
     return (
         <div>
             <CardThumbnail url={item.thumbnailUrls.tiny} />
@@ -572,6 +564,7 @@ function InsertableCard({ item }: { item: InsertableOut }): ReactNode {
 ```
 
 A few guidelines:
+
 - If you find yourself passing the same prop through multiple layers just so a deeply-nested component can use it, consider splitting the file or restructuring so the data is closer to where it's used.
 - Sub-components that are only used inside one parent file don't need to be exported — keep them unexported (no `export` keyword) so it's clear they're internal.
 - Sub-components that appear in more than one file belong in a shared file in the relevant feature directory.
@@ -584,13 +577,13 @@ A **hook** is a special function whose name starts with `use`. Hooks let you "ho
 
 React's built-in hooks you'll encounter in this codebase:
 
-| Hook | What it does |
-|------|-------------|
-| `useState` | Stores a piece of state; re-renders the component when it changes |
-| `useRef` | Holds a mutable value that does **not** trigger a re-render |
-| `useEffect` | Runs a side effect (e.g. set up a listener) after render |
-| `useLoaderData` | Reads the data returned by the current route's `loader` or `beforeLoad` function |
-| `useParams` | Reads path parameters from the current URL (e.g. `groupId` in `/app/groups/$groupId`) |
+| Hook            | What it does                                                                          |
+| --------------- | ------------------------------------------------------------------------------------- |
+| `useState`      | Stores a piece of state; re-renders the component when it changes                     |
+| `useRef`        | Holds a mutable value that does **not** trigger a re-render                           |
+| `useEffect`     | Runs a side effect (e.g. set up a listener) after render                              |
+| `useLoaderData` | Reads the data returned by the current route's `loader` or `beforeLoad` function      |
+| `useParams`     | Reads path parameters from the current URL (e.g. `groupId` in `/app/groups/$groupId`) |
 
 For the full rules and explanation see the [official React docs on hooks](https://react.dev/reference/rules/rules-of-hooks).
 
@@ -611,7 +604,7 @@ A custom hook is just a regular TypeScript function that starts with `use` and c
 
 Example from this codebase — `useUiState()` in `src/frontend/api-utils/ui-state.ts`:
 
-```ts
+```tsx
 // In ui-state.ts (a .ts file — no JSX, so no .tsx needed)
 export function useUiState(): [UiState, SetUiState] {
     const reactUiState = useSyncExternalStore(subscribeToUiState, getUiState);
@@ -633,6 +626,7 @@ function SearchBar(): ReactNode {
 The hook hides the `useSyncExternalStore` complexity so every component that needs UI state just calls `useUiState()`.
 
 When to write a custom hook vs. a plain function:
+
 - If your logic calls any React hook (`useState`, `useEffect`, etc.), it **must** be a hook (name starts with `use`, only called from components/hooks).
 - If your logic is pure computation with no hooks inside, make it a plain function.
 
@@ -659,8 +653,6 @@ The only SCSS file is `src/frontend/main.scss`, imported once in `main.tsx`. It 
 ```
 
 Prefer Mantine component props (`c=`, `bg=`, `p=`, `radius=`) over adding new SCSS when possible — Mantine props are theme-aware and respond to light/dark mode automatically. Add to `main.scss` only for truly global styles or utility classes that Mantine doesn't cover.
-
----
 
 ## The `apiGet` / `apiPost` / `apiDelete` Helpers
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -8,15 +8,9 @@ Step-by-step recipes for common development tasks. This guide assumes you've rea
 
 Before writing any code that talks to Onshape, start with **Glassworks** — Onshape's interactive API browser. It lets you explore every available endpoint, understand what parameters it accepts, send live requests, and inspect real responses. Think of it as a Postman-style tool built into Onshape.
 
+You can use Glassworks to see the list of publicly available APIs and test them against Onshape documents.
+
 **URL:** `https://cad.onshape.com/glassworks/explorer`
-
-### How to use it
-
-1. **Open Glassworks** in your browser. You'll see a list of API categories on the left (Documents, Assemblies, PartStudios, etc.).
-2. **Authenticate:** Click the green **Authorize** button at the top of the page. Log in with your Onshape account. This lets Glassworks make real API calls on your behalf.
-3. **Find your endpoint:** Browse the categories or use the search bar. Each endpoint shows its HTTP method (GET, POST, DELETE), path, and a description.
-4. **Try it out:** Click on an endpoint, then click **Try it out**. Fill in any required parameters (you can get document/workspace/element IDs from the URL of an Onshape document), then click **Execute**.
-5. **Inspect the response:** Glassworks shows the full JSON response, the HTTP status code, and the request URL. This is the ground truth for what you'll get when you call the same endpoint from code.
 
 **Tip:** The response shape you see in Glassworks is exactly what you'll get from `client.get(...)` in the backend. Use it to figure out what fields exist so you can type them correctly.
 
@@ -31,10 +25,13 @@ This is the most important concept to understand before adding any Onshape API i
 Everything in Onshape is nested: a **Document** contains one or more **Workspaces** (or Versions, or Microversions), and each Workspace contains **Elements** (tabs — Part Studios, Assemblies, Feature Studios, etc.).
 
 Each level has a unique string ID:
+
 - `documentId` — identifies the document
 - `instanceId` — identifies the workspace (or version, or microversion) within that document
 - `instanceType` — `"w"` for workspace, `"v"` for version, `"m"` for microversion
 - `elementId` — identifies a specific tab within the instance
+
+In the database, Groups correspond to Documents (or more specifically Versions of a Document) and Insertables correspond to Elements (tabs).
 
 ### Path types in the codebase
 
@@ -76,13 +73,16 @@ The `apiPath()` function in `src/backend/onshape-api/api-path.ts` assembles thes
 
 ```ts
 import { apiPath } from "../api-path";
-import { toInstanceApiPath, toElementApiPath } from "../../../shared/onshape-path";
+import {
+    toInstanceApiPath,
+    toElementApiPath
+} from "../../../shared/onshape-path";
 
 // Produces: /assemblies/d/{did}/w/{wid}/e/{eid}/features
-apiPath("assemblies", elementPath, toElementApiPath, { endRoute: "features" })
+apiPath("assemblies", elementPath, toElementApiPath, { endRoute: "features" });
 
 // Produces: /documents/d/{did}/w/{wid}/elements
-apiPath("documents", instancePath, toInstanceApiPath, { endRoute: "elements" })
+apiPath("documents", instancePath, toInstanceApiPath, { endRoute: "elements" });
 ```
 
 The serializer functions (`toDocumentApiPath`, `toInstanceApiPath`, `toElementApiPath`) are all defined in `src/shared/onshape-path.ts` and convert a path object into its URL segment string.
@@ -91,21 +91,13 @@ The serializer functions (`toDocumentApiPath`, `toInstanceApiPath`, `toElementAp
 
 ## Calling the Onshape API
 
-All Onshape API calls go through one of two classes defined in `src/backend/onshape-api/onshape-api.ts`:
-
-**`OAuthApi`** — Use this for requests made on behalf of a logged-in user. It adds the user's OAuth access token as a `Bearer` header. If the token has expired, it automatically refreshes it and retries. This is the class you'll almost always use.
-
-**`KeyApi`** — Use this for server-to-server requests that don't need a user session (e.g., background jobs that use a static API key). It signs requests with HMAC-SHA256.
-
-Both expose the same methods: `.get()`, `.post()`, `.delete()`, `.getImage()`, etc.
-
-In a route handler, you get an `OAuthApi` instance like this:
+All Onshape API calls go through the `OAuthApi` class, which is a wrapper around the Onshape API which handles authentication. For security reasons, the Onshape API is only available in the backend. The OAuthApi class can be retrieved inside any Hono route handler like this:
 
 ```ts
 const onshapeApi = await c.var.getOnshapeApi();
 ```
 
-Then pass it to any function in `src/backend/onshape-api/endpoints/`:
+You can then pass it to any function in `src/backend/onshape-api/endpoints/`:
 
 ```ts
 import { getDocumentElements } from "../onshape-api/endpoints/documents";
@@ -113,64 +105,7 @@ import { getDocumentElements } from "../onshape-api/endpoints/documents";
 const elements = await getDocumentElements(onshapeApi, instancePath);
 ```
 
-**Before writing a new wrapper function, check if it already exists** in one of the files under `src/backend/onshape-api/endpoints/`:
-
-| File | Wraps |
-|---|---|
-| `documents.ts` | Document metadata, workspaces, elements, references |
-| `assemblies.ts` | Assembly structure, adding elements, adding features, transforms |
-| `part-studios.ts` | Part Studio features |
-| `feature-studios.ts` | Feature Studio code (pull/push) |
-| `configurations.ts` | Configuration definitions and encoding |
-| `thumbnails.ts` | Element thumbnail images |
-| `users.ts` | User info, session ping |
-| `permissions.ts` | Permission checks |
-| `metadata.ts` | Element/part metadata |
-| `versions.ts` | Version listing |
-| `settings.ts` | Document settings |
-
----
-
-## Adding a New Onshape API Wrapper
-
-Use this when you need to call an Onshape endpoint that doesn't have a wrapper yet.
-
-### 1. Find the endpoint in Glassworks
-
-Go to `https://cad.onshape.com/glassworks/explorer`, find the endpoint, try it with a real document, and note the path structure and response shape.
-
-### 2. Add a wrapper function
-
-Find the right file in `src/backend/onshape-api/endpoints/` (or create a new one if the category is new). Add a typed function:
-
-```ts
-import { OnshapeApi } from "../onshape-api";
-import { ElementPath, toElementApiPath } from "../../../shared/onshape-path";
-import { apiPath } from "../api-path";
-
-/** Fetches the BOM for an assembly element. */
-export function getAssemblyBom(
-    client: OnshapeApi,
-    elementPath: ElementPath
-): Promise<any> {
-    return client.get(
-        apiPath("assemblies", elementPath, toElementApiPath, {
-            endRoute: "bom"
-        })
-    );
-}
-```
-
-A few notes:
-- Return type `Promise<any>` is fine to start. Once you know the response shape, define an interface and use that instead.
-- Use `apiPath()` to build the URL rather than constructing strings manually — it handles encoding and prefix logic for you.
-- For POST calls, pass `{ body: { ... } }` as the second argument to `client.post()`.
-
-### 3. Call it from a backend route
-
-Import your new function in the appropriate route file and call it inside a handler (see the next section).
-
----
+Before writing a new wrapper function, check if it already exists in one of the files under `src/backend/onshape-api/endpoints/`.
 
 ## Adding a New Backend Route
 
@@ -200,6 +135,7 @@ myRoutes.get("/my-thing" + libraryRoute(), async (c) => {
 ```
 
 **Route param helpers** (defined in `src/backend/app.ts`):
+
 - `libraryRoute()` — returns `"/library/:libraryId"`. Use `getLibraryParam(c)` to read it.
 - `insertableRoute()` — returns `"/insertable/:insertableId"`. Use `getInsertableParam(c)`.
 - `groupRoute()` — returns `"/group/:groupId"`. Use `getGroupParam(c)`.
@@ -228,8 +164,6 @@ app.route("/api", myRoutes);
 ### 3. Define the response type in shared
 
 If the frontend needs to consume this endpoint, define a TypeScript interface for the response in `src/shared/api-models.ts` so both sides agree on the shape.
-
----
 
 ## Modifying the Database Schema
 
@@ -270,8 +204,6 @@ This runs all pending migrations against your local D1 database (used by `npx wr
 ### 4. Update API response types if needed
 
 If the new data needs to be returned to the frontend, update the relevant interface in `src/shared/api-models.ts` and modify the query in `src/backend/library-data.ts` (if it's part of the main library response) or in the appropriate route handler.
-
----
 
 ## Adding a Frontend Route
 
@@ -346,7 +278,7 @@ Use TanStack Router's `<Link>` component for navigation:
 ```tsx
 import { Link } from "@tanstack/react-router";
 
-<Link to="/app/settings">Go to settings</Link>
+<Link to="/app/settings">Go to settings</Link>;
 ```
 
 ---
@@ -414,11 +346,10 @@ function MyButton({ id }: { id: string }) {
 }
 ```
 
----
-
 ## The `apiGet` / `apiPost` / `apiDelete` Helpers
 
 These are thin wrappers around `fetch` defined in `src/frontend/api-utils/api.ts`. They:
+
 - Automatically prepend `/api` to the path (so you write `"/context-data"` not `"/api/context-data"`)
 - Serialize query parameters via `URLSearchParams`
 - Append a `?v=` cache-busting parameter when `cacheId` is provided

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -2,8 +2,6 @@
 
 This document explains what FRCDesignApp is, how its pieces fit together, and where to find things in the codebase. If you want step-by-step recipes for adding new features, see [GUIDE.md](./GUIDE.md).
 
----
-
 ## What Is This App?
 
 FRCDesignApp is a part-library browser that runs **inside Onshape** as an embedded tab (technically an iframe). When a user opens an Onshape part studio or assembly document, they can open this app in a side panel, browse a curated library of FRC robot parts organized into groups, and click a part to insert it into an assembly or derive it into their part studio.
@@ -12,12 +10,7 @@ The app reflects underlying Onshape documents that are owned and maintained by t
 
 The app is hosted on Cloudflare. The frontend is served by Cloudflare as a Single Page Application (SPA) to the user's browser, meaning the frontend code loads and executes directly in the user's browser. The backend runs on Cloudflare, exposes endpoints for the frontend to call, and handles access to resources like the database and Onshape. For security, all communication with the Onshape API is routed through the backend.
 
----
-
-## Tech Stack
-
-| Layer | Technology | Why |
-|---|---|---|
+-------------------- | ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | Frontend UI | React 19 + [Mantine](https://mantine.dev/) | React for component model; Mantine for a rich set of pre-built accessible UI components (modals, menus, notifications, etc.) |
 | Frontend routing | [TanStack Router](https://tanstack.com/router) | File-based routing: each `.tsx` file under `src/frontend/routes/` automatically becomes a URL route. Type-safe navigation. |
 | Server-state caching | [TanStack Query (React Query)](https://tanstack.com/query) | Handles fetching, caching, and revalidating data from the backend. Prevents redundant network requests and keeps the UI in sync. |
@@ -26,8 +19,6 @@ The app is hosted on Cloudflare. The frontend is served by Cloudflare as a Singl
 | Build tool | [Vite](https://vite.dev/) + `@cloudflare/vite-plugin` | Bundles both the React SPA and the Cloudflare Worker in one build step. |
 | Validation | [Zod](https://zod.dev/) | Runtime schema validation, used for API responses, URL params, and localStorage state. |
 | Testing | [Vitest](https://vitest.dev/) + `@cloudflare/vitest-pool-workers` | Runs tests inside a Workers runtime so tests accurately reflect the production environment. |
-
----
 
 ## Cloudflare Services
 
@@ -68,8 +59,6 @@ The compiled React app (HTML, JS, CSS) is served directly by Cloudflare's asset 
 
 The asset binding is configured with `single-page-application` mode, which means any unrecognized path serves `index.html` — necessary for client-side routing to work.
 
----
-
 ## How Users Get Into the App
 
 This app runs inside an Onshape iframe, which adds some authentication complexity. Here is the complete flow from first page load to seeing the part library.
@@ -103,19 +92,15 @@ Once the backend confirms authentication and serves the React app, the frontend 
 4. The `/app` route's `loader` uses the `cacheVersion` to kick off three prefetches in parallel: the full library data, the search index, and the user's favorites.
 5. With all data already in the React Query cache, the groups page renders immediately with no loading spinners.
 
----
-
 ## Storage at a Glance
 
-| Store | What it holds | Lifetime | Who reads/writes it |
-|---|---|---|---|
-| **D1** | Library data, groups, parts (insertables), configurations, user preferences, favorites | Permanent (until explicitly changed) | Backend Worker on every API request |
-| **KV** | OAuth session state (during login) and auth tokens (after login) | Login state: 10 minutes. Tokens: 30 days. | Backend Worker in `src/backend/auth.ts` |
-| **R2** | Part and group thumbnail images | Indefinite (30-day browser cache-control) | Backend Worker in `src/backend/routes/thumbnails.ts` |
-| **localStorage** | UI state: open/closed panels, active search query, vendor filters, last-opened group | Persists across browser sessions | Frontend only, via `src/frontend/api-utils/ui-state.ts` |
-| **sessionStorage** | Not used | — | — |
-
----
+| Store              | What it holds                                                                          | Lifetime                                  | Who reads/writes it                                     |
+| ------------------ | -------------------------------------------------------------------------------------- | ----------------------------------------- | ------------------------------------------------------- |
+| **D1**             | Library data, groups, parts (insertables), configurations, user preferences, favorites | Permanent (until explicitly changed)      | Backend Worker on every API request                     |
+| **KV**             | OAuth session state (during login) and auth tokens (after login)                       | Login state: 10 minutes. Tokens: 30 days. | Backend Worker in `src/backend/auth.ts`                 |
+| **R2**             | Part and group thumbnail images                                                        | Indefinite (30-day browser cache-control) | Backend Worker in `src/backend/routes/thumbnails.ts`    |
+| **localStorage**   | UI state: open/closed panels, active search query, vendor filters, last-opened group   | Persists across browser sessions          | Frontend only, via `src/frontend/api-utils/ui-state.ts` |
+| **sessionStorage** | Not used                                                                               | —                                         | —                                                       |
 
 ## Codebase Map
 
@@ -135,11 +120,10 @@ Code used by both the frontend and backend. Key files:
 The Cloudflare Worker. Key files and folders:
 
 - `index.ts` — Worker entry point; exports the Hono app and the Workflow class
-- `create-app.ts` — mounts all route groups and injects services into the Hono context
 - `auth.ts` — OAuth flow, session cookie management, token storage/retrieval
 - `services.ts` — provides `getOnshapeApi()`, `getUserId()`, `getAccessLevel()` to route handlers
 - `library-data.ts` — assembles the full library response (groups + insertables + configurations)
-- `routes/` — one file per logical area (`user.ts`, `library.ts`, `groups.ts`, `insertables.ts`, `favorites.ts`, `thumbnails.ts`, `configurations.ts`)
+- `routes/` — endpoints callable by the frontend
 - `onshape-api/` — all code that communicates with Onshape's REST API (`onshape-api.ts` for the client class, `api-path.ts` for URL construction, `endpoints/` for per-category wrappers)
 - `parse/` — `load-document.ts` runs the Cloudflare Workflow that syncs an Onshape document into D1
 
@@ -158,8 +142,6 @@ Other top-level files:
 
 - `drizzle/` — SQL migration files generated by Drizzle Kit
 - `wrangler.jsonc` — Cloudflare Workers config (bindings, routes, env vars)
-
----
 
 ## Access Levels
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -1,0 +1,220 @@
+# FRCDesignApp — System Reference
+
+This document explains what FRCDesignApp is, how its pieces fit together, and where to find things in the codebase. If you want step-by-step recipes for adding new features, see [GUIDE.md](./GUIDE.md).
+
+---
+
+## What Is This App?
+
+FRCDesignApp is a part-library browser that runs **inside Onshape** as an embedded tab (technically an iframe). When a user opens an Onshape assembly document, they can open this app in a side panel, browse a curated library of FRC robot parts organized into groups, and click a part to insert it directly into their assembly.
+
+The app is hosted on **Cloudflare's edge network**, so there is no traditional server — instead, all backend logic runs as a Cloudflare Worker (a serverless function that runs close to the user). The frontend is a React single-page application served as static files from the same Cloudflare deployment.
+
+---
+
+## Tech Stack
+
+| Layer | Technology | Why |
+|---|---|---|
+| Frontend UI | React 19 + [Mantine](https://mantine.dev/) | React for component model; Mantine for a rich set of pre-built accessible UI components (modals, menus, notifications, etc.) |
+| Frontend routing | [TanStack Router](https://tanstack.com/router) | File-based routing: each `.tsx` file under `src/frontend/routes/` automatically becomes a URL route. Type-safe navigation. |
+| Server-state caching | [TanStack Query (React Query)](https://tanstack.com/query) | Handles fetching, caching, and revalidating data from the backend. Prevents redundant network requests and keeps the UI in sync. |
+| Backend framework | [Hono](https://hono.dev/) | A lightweight HTTP framework (similar to Express, but designed for edge runtimes like Cloudflare Workers). |
+| Database ORM | [Drizzle ORM](https://orm.drizzle.team/) | Type-safe SQL query builder. Schema is defined in TypeScript and migrations are generated automatically. |
+| Build tool | [Vite](https://vite.dev/) + `@cloudflare/vite-plugin` | Bundles both the React SPA and the Cloudflare Worker in one build step. |
+| Validation | [Zod](https://zod.dev/) | Runtime schema validation, used for API responses, URL params, and localStorage state. |
+| Testing | [Vitest](https://vitest.dev/) + `@cloudflare/vitest-pool-workers` | Runs tests inside a Workers runtime so tests accurately reflect the production environment. |
+
+---
+
+## Cloudflare Services
+
+The app uses five Cloudflare products. Each one is declared as a **binding** in `wrangler.jsonc` and accessed in Worker code via `c.env.<BINDING_NAME>`.
+
+### D1 — The Database (`c.env.DB`)
+
+D1 is Cloudflare's managed SQLite database. It is the app's primary persistent store — everything about libraries, groups, parts, users, and favorites lives here.
+
+Queries go through **Drizzle ORM** so you write TypeScript instead of raw SQL. The schema is defined in `src/shared/schema.ts`. SQL migration files live in `drizzle/` and are applied automatically on deploy.
+
+**Tables:** `libraries`, `groups`, `insertables`, `configurations`, `users`, `favorites`
+
+### KV — Session & Token Storage (`c.env.KV`)
+
+KV is a key-value store (like a global dictionary). The app uses it exclusively for **authentication**:
+
+- During the OAuth login flow, it briefly stores the OAuth `state` and the URL to redirect back to after login.
+- After login succeeds, it stores the user's access token and refresh token, keyed to their session cookie.
+
+KV is the right tool here because Cloudflare Workers are stateless — there is no in-memory session that persists between requests. KV gives us a fast, durable place to stash tokens between requests.
+
+### R2 — Thumbnail Storage (`c.env.THUMBNAILS`)
+
+R2 is Cloudflare's object storage (similar to Amazon S3). The app uses it as a **thumbnail image cache**.
+
+Onshape can generate preview thumbnails for parts and assemblies, but fetching them from Onshape on every page load would be slow and eat into API rate limits. Instead, we fetch a thumbnail from Onshape the first time it's needed, store it in R2, and serve it from R2 on all subsequent requests. Thumbnails are served via `/api/thumbnail/:size/:elementId`.
+
+### Workflows — Document Sync (`c.env.LOAD_DOCUMENT_WORKFLOW`)
+
+Cloudflare Workflows let you run a long-running background job that survives beyond a single HTTP request's time limit.
+
+When a user adds a new group (a new Onshape document) to the library, the app needs to walk the entire document structure, download metadata for every part and assembly, generate thumbnails, and write everything to D1. This can take many seconds — too long to do in a single HTTP request without timing out.
+
+The `LoadDocumentWorkflow` class (defined in `src/backend/parse/load-document.ts`) handles this process as a background job. The HTTP request just kicks it off and returns immediately; the workflow runs to completion independently.
+
+### Assets — Static File Serving (`c.env.ASSETS`)
+
+The compiled React app (HTML, JS, CSS) is served directly by Cloudflare's asset infrastructure. The Worker only intercepts three path patterns: `/init`, `/api/*`, and `/auth/*`. Everything else (the SPA files, icons, fonts) is served from the static asset bundle without going through Worker code.
+
+The asset binding is configured with `single-page-application` mode, which means any unrecognized path serves `index.html` — necessary for client-side routing to work.
+
+---
+
+## How Users Get Into the App
+
+This app runs inside an Onshape iframe, which adds some authentication complexity. Here is the complete flow from first page load to seeing the part library.
+
+### Normal flow (already logged in)
+
+1. Onshape loads the app's iframe by navigating to `/init?documentId=...&workspaceId=...&elementId=...` with the current document's identifiers in the URL.
+2. The Worker checks if the request has a valid session cookie (`frc-design-app-cookie`) and whether the stored tokens are still valid.
+3. If everything checks out, the Worker serves the React app (`index.html`), which then loads and navigates to `/app/groups`.
+4. The React app calls `/api/context-data` to get user info and access level, then prefetches the library data, search index, and favorites.
+5. The UI renders.
+
+### First-time flow (OAuth)
+
+1. Same as above — Onshape loads `/init`.
+2. The Worker finds no valid session cookie. It redirects to `/auth/sign-in?redirectUrl=<the /init URL>`.
+3. The sign-in handler generates a random `state` string (a security measure), stores `{ state, redirectUrl }` in KV under a random session ID, sets the session cookie, and redirects the user to Onshape's OAuth login page.
+4. The user sees the Onshape "Authorize App" screen and clicks approve.
+5. Onshape redirects back to `/auth/callback?code=...&state=...`.
+6. The callback handler reads the session from KV, verifies the `state` matches (preventing CSRF attacks), and exchanges the `code` for real access and refresh tokens using the [Arctic](https://arcticjs.dev/) OAuth library.
+7. The tokens are saved to KV under the session ID. The temporary login-session entry is deleted.
+8. The user is redirected back to the original `/init` URL, which now succeeds because the session cookie and tokens are in place.
+
+### Token refresh
+
+Access tokens expire. When any Onshape API call returns a `401 Unauthorized`, `OAuthApi` automatically calls Onshape's token endpoint with the stored refresh token to get a new access token, saves it to KV, and retries the original request — all transparently.
+
+### Why `SameSite=None` on the cookie?
+
+The app runs inside an Onshape iframe. Browsers block cookies from being sent in cross-site iframes unless the cookie has `SameSite=None; Secure`. Without this, the session cookie would never be sent and the user would be stuck in an auth loop.
+
+---
+
+## Storage at a Glance
+
+| Store | What it holds | Lifetime | Who reads/writes it |
+|---|---|---|---|
+| **D1** | Library data, groups, parts (insertables), configurations, user preferences, favorites | Permanent (until explicitly changed) | Backend Worker on every API request |
+| **KV** | OAuth session state (during login) and auth tokens (after login) | Login state: 10 minutes. Tokens: 30 days. | Backend Worker in `src/backend/auth.ts` |
+| **R2** | Part and group thumbnail images | Indefinite (30-day browser cache-control) | Backend Worker in `src/backend/routes/thumbnails.ts` |
+| **localStorage** | UI state: open/closed panels, active search query, vendor filters, last-opened group | Persists across browser sessions | Frontend only, via `src/frontend/api-utils/ui-state.ts` |
+| **sessionStorage** | Not used | — | — |
+
+---
+
+## Codebase Map
+
+```
+FRCDesignApp/
+├── src/
+│   ├── backend/              # Cloudflare Worker — all server-side code
+│   │   ├── index.ts          # Worker entry point; exports the Hono app and the Workflow class
+│   │   ├── app.ts            # Hono app factory, AppBindings/AppContext types, route-param helpers
+│   │   ├── create-app.ts     # Composition root: mounts all route groups onto the Hono app
+│   │   ├── auth.ts           # OAuth flow, session cookie management, token storage/retrieval
+│   │   ├── db.ts             # Drizzle ORM client factory (wraps c.env.DB)
+│   │   ├── services.ts       # Dependency injection: getOnshapeApi(), getUserId(), getAccessLevel()
+│   │   ├── library-data.ts   # Assembles full library response (groups + insertables + configs)
+│   │   ├── access-level-utils.ts  # requireEditorMiddleware, requireAdminMiddleware
+│   │   ├── routes/           # One file per logical area; each exports a Hono sub-app
+│   │   │   ├── user.ts       # GET /api/context-data, GET /api/unit-info
+│   │   │   ├── library.ts    # GET /api/library-data/library/:libraryId, GET /api/search-db/...
+│   │   │   ├── groups.ts     # POST /api/add-group, POST /api/rename-group, DELETE /api/group/:id
+│   │   │   ├── insertables.ts  # POST /api/toggle-open-composite, POST /api/toggle-insert-and-fasten
+│   │   │   ├── favorites.ts  # CRUD for user favorites
+│   │   │   ├── thumbnails.ts # GET /api/thumbnail/:size/:elementId (serves from R2)
+│   │   │   └── configurations.ts  # POST /api/save-configuration
+│   │   ├── onshape-api/      # All code that talks to Onshape's REST API
+│   │   │   ├── onshape-api.ts   # OnshapeApi base class, OAuthApi, KeyApi
+│   │   │   ├── api-path.ts      # apiPath() — builds Onshape REST URL paths
+│   │   │   └── endpoints/    # One file per Onshape API category
+│   │   │       ├── documents.ts
+│   │   │       ├── assemblies.ts
+│   │   │       ├── part-studios.ts
+│   │   │       ├── feature-studios.ts
+│   │   │       ├── configurations.ts
+│   │   │       ├── thumbnails.ts
+│   │   │       ├── users.ts
+│   │   │       ├── permissions.ts
+│   │   │       ├── metadata.ts
+│   │   │       ├── versions.ts
+│   │   │       └── settings.ts
+│   │   └── parse/            # Document sync logic
+│   │       ├── load-document.ts     # LoadDocumentWorkflow — syncs an Onshape document into D1
+│   │       ├── parse-configuration.ts  # Parses Onshape feature configs into app model
+│   │       └── insert-and-fasten.ts  # Derives fasten/mate info for assemblies
+│   │
+│   ├── frontend/             # React SPA
+│   │   ├── main.tsx          # React root — wraps the app in providers (QueryClient, Mantine)
+│   │   ├── router.ts         # Creates TanStack Router instance from the generated route tree
+│   │   ├── routeTree.gen.ts  # Auto-generated by TanStack Router; do not edit by hand
+│   │   ├── queries.ts        # React Query query definitions (getLibraryQuery, getFavoritesQuery, etc.)
+│   │   ├── query-client.ts   # Configured React Query client
+│   │   ├── theme.ts          # Mantine theme configuration
+│   │   ├── routes/           # File-based routes — each file = one URL
+│   │   │   ├── __root.tsx    # Root layout: providers, loads context-data
+│   │   │   ├── init.tsx      # Entry point from Onshape; auth guard
+│   │   │   ├── app/
+│   │   │   │   ├── route.tsx      # App shell (header, sidebar); prefetches library + favorites
+│   │   │   │   └── groups/
+│   │   │   │       ├── index.tsx  # Groups list view
+│   │   │   │       └── $groupId.tsx  # Individual group view
+│   │   │   └── _pages/       # Standalone error pages (safari-error, cookie-error, etc.)
+│   │   ├── api-utils/        # Frontend helpers for talking to the backend
+│   │   │   ├── api.ts        # apiGet(), apiPost(), apiDelete() — thin fetch wrappers
+│   │   │   ├── ui-state.ts   # localStorage-backed UI state with React hook
+│   │   │   ├── library.ts    # useLibraryId(), toLibraryPath() helpers
+│   │   │   ├── access-level.tsx  # RequireAccessLevel guard component
+│   │   │   └── onshape-params.ts  # Reads theme/document params passed in from Onshape
+│   │   ├── cards/            # Insertable card components
+│   │   ├── insert/           # Insert dialog and configuration selector
+│   │   ├── favorites/        # Favorites sidebar and management UI
+│   │   ├── groups/           # Group card and add-group menu
+│   │   ├── search/           # Full-text search (backed by MiniSearch)
+│   │   └── settings/         # Theme and vendor-filter settings
+│   │
+│   └── shared/               # Code used by both frontend and backend
+│       ├── schema.ts         # Drizzle table definitions (the database schema)
+│       ├── types.ts          # Shared enums (AccessLevel, Vendor, Theme) and core interfaces
+│       ├── api-models.ts     # TypeScript types for API request/response shapes
+│       ├── configuration-models.ts  # Types for Onshape configuration parameters
+│       ├── onshape-path.ts   # ElementPath, InstancePath types + serialization helpers
+│       └── search.ts         # MiniSearch index configuration
+│
+├── drizzle/                  # SQL migration files (generated by Drizzle Kit, committed to repo)
+├── public/                   # Static assets (favicon, icons)
+├── wrangler.jsonc            # Cloudflare Workers config: bindings, routes, env vars
+├── vite.config.ts            # Vite build config
+└── vitest.config.ts          # Vitest test config
+```
+
+---
+
+## Access Levels
+
+The app has three access levels, checked on every protected API call:
+
+| Level | Who | What they can do |
+|---|---|---|
+| **ADMIN** | Members of the Onshape team specified by the `ADMIN_TEAM` binding | Everything: add/remove/rename groups, toggle insertable visibility, manage the library |
+| **EDITOR** | (Currently same check as admin, but the concept is separate) | Add and rename groups |
+| **USER** | Anyone who successfully logs in via OAuth | Browse the library, insert parts, manage their own favorites |
+
+The Worker determines a user's access level in `src/backend/services.ts` by calling the Onshape API to check team membership. The result is cached per-request via the Hono context.
+
+Backend routes that require elevated access are wrapped with `requireEditorMiddleware` or `requireAdminMiddleware` from `src/backend/access-level-utils.ts`.
+
+During local development, you can bypass the team membership check by setting `ACCESS_LEVEL_OVERRIDE=admin` (or `editor`/`user`) in your `.env` file.

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -6,9 +6,11 @@ This document explains what FRCDesignApp is, how its pieces fit together, and wh
 
 ## What Is This App?
 
-FRCDesignApp is a part-library browser that runs **inside Onshape** as an embedded tab (technically an iframe). When a user opens an Onshape assembly document, they can open this app in a side panel, browse a curated library of FRC robot parts organized into groups, and click a part to insert it directly into their assembly.
+FRCDesignApp is a part-library browser that runs **inside Onshape** as an embedded tab (technically an iframe). When a user opens an Onshape part studio or assembly document, they can open this app in a side panel, browse a curated library of FRC robot parts organized into groups, and click a part to insert it into an assembly or derive it into their part studio.
 
-The app is hosted on **Cloudflare's edge network**, so there is no traditional server — instead, all backend logic runs as a Cloudflare Worker (a serverless function that runs close to the user). The frontend is a React single-page application served as static files from the same Cloudflare deployment.
+The app reflects underlying Onshape documents that are owned and maintained by the FRCDesignLib team. Parts reflect the underlying Onshape documents — for example, part names come from the names of the underlying tabs, and configurations reflect the settings defined in Onshape.
+
+The app is hosted on Cloudflare. The frontend is served by Cloudflare as a Single Page Application (SPA) to the user's browser, meaning the frontend code loads and executes directly in the user's browser. The backend runs on Cloudflare, exposes endpoints for the frontend to call, and handles access to resources like the database and Onshape. For security, all communication with the Onshape API is routed through the backend.
 
 ---
 
@@ -37,8 +39,6 @@ D1 is Cloudflare's managed SQLite database. It is the app's primary persistent s
 
 Queries go through **Drizzle ORM** so you write TypeScript instead of raw SQL. The schema is defined in `src/shared/schema.ts`. SQL migration files live in `drizzle/` and are applied automatically on deploy.
 
-**Tables:** `libraries`, `groups`, `insertables`, `configurations`, `users`, `favorites`
-
 ### KV — Session & Token Storage (`c.env.KV`)
 
 KV is a key-value store (like a global dictionary). The app uses it exclusively for **authentication**:
@@ -46,11 +46,11 @@ KV is a key-value store (like a global dictionary). The app uses it exclusively 
 - During the OAuth login flow, it briefly stores the OAuth `state` and the URL to redirect back to after login.
 - After login succeeds, it stores the user's access token and refresh token, keyed to their session cookie.
 
-KV is the right tool here because Cloudflare Workers are stateless — there is no in-memory session that persists between requests. KV gives us a fast, durable place to stash tokens between requests.
+KV serves as a cheap, lightweight way to persist user data across multiple Cloudflare Workers (which Cloudflare automatically scales and provisions based on the app's current traffic). Because Workers are stateless — there is no in-memory session that persists between requests — KV is the right place to stash tokens between requests.
 
 ### R2 — Thumbnail Storage (`c.env.THUMBNAILS`)
 
-R2 is Cloudflare's object storage (similar to Amazon S3). The app uses it as a **thumbnail image cache**.
+R2 is Cloudflare's blob storage, optimized for unstructured data like images and PDFs. The app uses it to store and cache thumbnails in order to improve reliability.
 
 Onshape can generate preview thumbnails for parts and assemblies, but fetching them from Onshape on every page load would be slow and eat into API rate limits. Instead, we fetch a thumbnail from Onshape the first time it's needed, store it in R2, and serve it from R2 on all subsequent requests. Thumbnails are served via `/api/thumbnail/:size/:elementId`.
 
@@ -93,13 +93,15 @@ This app runs inside an Onshape iframe, which adds some authentication complexit
 7. The tokens are saved to KV under the session ID. The temporary login-session entry is deleted.
 8. The user is redirected back to the original `/init` URL, which now succeeds because the session cookie and tokens are in place.
 
-### Token refresh
+### What happens on the client after auth
 
-Access tokens expire. When any Onshape API call returns a `401 Unauthorized`, `OAuthApi` automatically calls Onshape's token endpoint with the stored refresh token to get a new access token, saves it to KV, and retries the original request — all transparently.
+Once the backend confirms authentication and serves the React app, the frontend takes over:
 
-### Why `SameSite=None` on the cookie?
-
-The app runs inside an Onshape iframe. Browsers block cookies from being sent in cross-site iframes unless the cookie has `SameSite=None; Secure`. Without this, the session cookie would never be sent and the user would be stuck in an auth loop.
+1. The `/init` route normalizes the Onshape URL parameters (document ID, workspace ID, element ID, theme, etc.) and stores them in the URL query string. TanStack Router carries these parameters forward automatically via `retainSearchParams`, so child routes can always read them.
+2. `/init`'s `beforeLoad` immediately redirects to `/app/groups` (or to the last-opened group if one is saved in `localStorage`).
+3. The `/app` route's `beforeLoad` calls `getContextDataQuery()` — a blocking fetch that retrieves user settings (including the `libraryId` and `cacheVersion`) and access level before any child route renders.
+4. The `/app` route's `loader` uses the `cacheVersion` to kick off three prefetches in parallel: the full library data, the search index, and the user's favorites.
+5. With all data already in the React Query cache, the groups page renders immediately with no loading spinners.
 
 ---
 
@@ -117,104 +119,52 @@ The app runs inside an Onshape iframe. Browsers block cookies from being sent in
 
 ## Codebase Map
 
-```
-FRCDesignApp/
-├── src/
-│   ├── backend/              # Cloudflare Worker — all server-side code
-│   │   ├── index.ts          # Worker entry point; exports the Hono app and the Workflow class
-│   │   ├── app.ts            # Hono app factory, AppBindings/AppContext types, route-param helpers
-│   │   ├── create-app.ts     # Composition root: mounts all route groups onto the Hono app
-│   │   ├── auth.ts           # OAuth flow, session cookie management, token storage/retrieval
-│   │   ├── db.ts             # Drizzle ORM client factory (wraps c.env.DB)
-│   │   ├── services.ts       # Dependency injection: getOnshapeApi(), getUserId(), getAccessLevel()
-│   │   ├── library-data.ts   # Assembles full library response (groups + insertables + configs)
-│   │   ├── access-level-utils.ts  # requireEditorMiddleware, requireAdminMiddleware
-│   │   ├── routes/           # One file per logical area; each exports a Hono sub-app
-│   │   │   ├── user.ts       # GET /api/context-data, GET /api/unit-info
-│   │   │   ├── library.ts    # GET /api/library-data/library/:libraryId, GET /api/search-db/...
-│   │   │   ├── groups.ts     # POST /api/add-group, POST /api/rename-group, DELETE /api/group/:id
-│   │   │   ├── insertables.ts  # POST /api/toggle-open-composite, POST /api/toggle-insert-and-fasten
-│   │   │   ├── favorites.ts  # CRUD for user favorites
-│   │   │   ├── thumbnails.ts # GET /api/thumbnail/:size/:elementId (serves from R2)
-│   │   │   └── configurations.ts  # POST /api/save-configuration
-│   │   ├── onshape-api/      # All code that talks to Onshape's REST API
-│   │   │   ├── onshape-api.ts   # OnshapeApi base class, OAuthApi, KeyApi
-│   │   │   ├── api-path.ts      # apiPath() — builds Onshape REST URL paths
-│   │   │   └── endpoints/    # One file per Onshape API category
-│   │   │       ├── documents.ts
-│   │   │       ├── assemblies.ts
-│   │   │       ├── part-studios.ts
-│   │   │       ├── feature-studios.ts
-│   │   │       ├── configurations.ts
-│   │   │       ├── thumbnails.ts
-│   │   │       ├── users.ts
-│   │   │       ├── permissions.ts
-│   │   │       ├── metadata.ts
-│   │   │       ├── versions.ts
-│   │   │       └── settings.ts
-│   │   └── parse/            # Document sync logic
-│   │       ├── load-document.ts     # LoadDocumentWorkflow — syncs an Onshape document into D1
-│   │       ├── parse-configuration.ts  # Parses Onshape feature configs into app model
-│   │       └── insert-and-fasten.ts  # Derives fasten/mate info for assemblies
-│   │
-│   ├── frontend/             # React SPA
-│   │   ├── main.tsx          # React root — wraps the app in providers (QueryClient, Mantine)
-│   │   ├── router.ts         # Creates TanStack Router instance from the generated route tree
-│   │   ├── routeTree.gen.ts  # Auto-generated by TanStack Router; do not edit by hand
-│   │   ├── queries.ts        # React Query query definitions (getLibraryQuery, getFavoritesQuery, etc.)
-│   │   ├── query-client.ts   # Configured React Query client
-│   │   ├── theme.ts          # Mantine theme configuration
-│   │   ├── routes/           # File-based routes — each file = one URL
-│   │   │   ├── __root.tsx    # Root layout: providers, loads context-data
-│   │   │   ├── init.tsx      # Entry point from Onshape; auth guard
-│   │   │   ├── app/
-│   │   │   │   ├── route.tsx      # App shell (header, sidebar); prefetches library + favorites
-│   │   │   │   └── groups/
-│   │   │   │       ├── index.tsx  # Groups list view
-│   │   │   │       └── $groupId.tsx  # Individual group view
-│   │   │   └── _pages/       # Standalone error pages (safari-error, cookie-error, etc.)
-│   │   ├── api-utils/        # Frontend helpers for talking to the backend
-│   │   │   ├── api.ts        # apiGet(), apiPost(), apiDelete() — thin fetch wrappers
-│   │   │   ├── ui-state.ts   # localStorage-backed UI state with React hook
-│   │   │   ├── library.ts    # useLibraryId(), toLibraryPath() helpers
-│   │   │   ├── access-level.tsx  # RequireAccessLevel guard component
-│   │   │   └── onshape-params.ts  # Reads theme/document params passed in from Onshape
-│   │   ├── cards/            # Insertable card components
-│   │   ├── insert/           # Insert dialog and configuration selector
-│   │   ├── favorites/        # Favorites sidebar and management UI
-│   │   ├── groups/           # Group card and add-group menu
-│   │   ├── search/           # Full-text search (backed by MiniSearch)
-│   │   └── settings/         # Theme and vendor-filter settings
-│   │
-│   └── shared/               # Code used by both frontend and backend
-│       ├── schema.ts         # Drizzle table definitions (the database schema)
-│       ├── types.ts          # Shared enums (AccessLevel, Vendor, Theme) and core interfaces
-│       ├── api-models.ts     # TypeScript types for API request/response shapes
-│       ├── configuration-models.ts  # Types for Onshape configuration parameters
-│       ├── onshape-path.ts   # ElementPath, InstancePath types + serialization helpers
-│       └── search.ts         # MiniSearch index configuration
-│
-├── drizzle/                  # SQL migration files (generated by Drizzle Kit, committed to repo)
-├── public/                   # Static assets (favicon, icons)
-├── wrangler.jsonc            # Cloudflare Workers config: bindings, routes, env vars
-├── vite.config.ts            # Vite build config
-└── vitest.config.ts          # Vitest test config
-```
+The source code lives in three directories under `src/`:
+
+### `src/shared/`
+
+Code used by both the frontend and backend. Key files:
+
+- `schema.ts` — Drizzle table definitions (the database schema)
+- `types.ts` — shared enums (`AccessLevel`, `Vendor`, `Theme`) and core interfaces
+- `api-models.ts` — TypeScript types for API request/response shapes
+- `onshape-path.ts` — `ElementPath`, `InstancePath` types and the serialization helpers used to build Onshape REST URLs
+
+### `src/backend/`
+
+The Cloudflare Worker. Key files and folders:
+
+- `index.ts` — Worker entry point; exports the Hono app and the Workflow class
+- `create-app.ts` — mounts all route groups and injects services into the Hono context
+- `auth.ts` — OAuth flow, session cookie management, token storage/retrieval
+- `services.ts` — provides `getOnshapeApi()`, `getUserId()`, `getAccessLevel()` to route handlers
+- `library-data.ts` — assembles the full library response (groups + insertables + configurations)
+- `routes/` — one file per logical area (`user.ts`, `library.ts`, `groups.ts`, `insertables.ts`, `favorites.ts`, `thumbnails.ts`, `configurations.ts`)
+- `onshape-api/` — all code that communicates with Onshape's REST API (`onshape-api.ts` for the client class, `api-path.ts` for URL construction, `endpoints/` for per-category wrappers)
+- `parse/` — `load-document.ts` runs the Cloudflare Workflow that syncs an Onshape document into D1
+
+### `src/frontend/`
+
+The React SPA. Key files and folders:
+
+- `main.tsx` — React root; wraps the app in `QueryClientProvider` and `MantineProvider`
+- `queries.ts` — React Query query definitions shared across the app
+- `routes/` — file-based routes (`__root.tsx`, `init.tsx`, `app/route.tsx`, `app/groups/index.tsx`, `app/groups/$groupId.tsx`)
+- `api-utils/` — helpers for talking to the backend (`api.ts` for fetch wrappers, `ui-state.ts` for localStorage state, `library.ts` for library ID helpers)
+
+Everything else under `src/frontend/` is organized by feature: `cards/`, `insert/`, `favorites/`, `groups/`, `search/`, `settings/`.
+
+Other top-level files:
+
+- `drizzle/` — SQL migration files generated by Drizzle Kit
+- `wrangler.jsonc` — Cloudflare Workers config (bindings, routes, env vars)
 
 ---
 
 ## Access Levels
 
-The app has three access levels, checked on every protected API call:
+The app has three access levels, checked on every protected API call: **ADMIN**, **EDITOR**, and **USER**. Admin and editor access currently grant the same permissions (adding, removing, and renaming groups, toggling insertable visibility), but they are kept separate so permissions can be tightened in the future if needed. USER access allows anyone who logs in via OAuth to browse the library, insert parts, and manage their own favorites.
 
-| Level | Who | What they can do |
-|---|---|---|
-| **ADMIN** | Members of the Onshape team specified by the `ADMIN_TEAM` binding | Everything: add/remove/rename groups, toggle insertable visibility, manage the library |
-| **EDITOR** | (Currently same check as admin, but the concept is separate) | Add and rename groups |
-| **USER** | Anyone who successfully logs in via OAuth | Browse the library, insert parts, manage their own favorites |
-
-The Worker determines a user's access level in `src/backend/services.ts` by calling the Onshape API to check team membership. The result is cached per-request via the Hono context.
-
-Backend routes that require elevated access are wrapped with `requireEditorMiddleware` or `requireAdminMiddleware` from `src/backend/access-level-utils.ts`.
+The Worker determines a user's access level in `src/backend/services.ts` by calling the Onshape API to check team membership against the `ADMIN_TEAM` binding. Backend routes that require elevated access are wrapped with `requireEditorMiddleware` or `requireAdminMiddleware` from `src/backend/access-level-utils.ts`.
 
 During local development, you can bypass the team membership check by setting `ACCESS_LEVEL_OVERRIDE=admin` (or `editor`/`user`) in your `.env` file.


### PR DESCRIPTION
## Summary

Adds two Markdown documentation files under `docs/` aimed at new contributors who may not be familiar with Cloudflare Workers, Hono, or TanStack Router.

- **`docs/REFERENCE.md`** — System reference for understanding the app. Covers what the app is, the full tech stack with plain-language explanations, all five Cloudflare services (D1, KV, R2, Workflows, Assets) and why each is used, the complete OAuth auth flow step-by-step, a storage-at-a-glance table, a full codebase map with one-line descriptions per file/directory, and access levels (ADMIN/EDITOR/USER).

- **`docs/GUIDE.md`** — Developer task guide for implementing new features. Covers using the Onshape Glassworks API Explorer, understanding Onshape document paths (`DocumentPath` / `InstancePath` / `ElementPath` and `apiPath()`), adding new Onshape API wrapper functions, adding new backend Hono routes, modifying the Drizzle DB schema and generating migrations, adding TanStack Router frontend routes, and wiring up React Query data fetches and mutations.

## Test plan

- [ ] Read through both files for accuracy against the actual codebase
- [ ] Confirm code examples in GUIDE.md match real patterns (route handlers, `apiPath()` calls, `queryOptions` usage)
- [ ] Confirm all file paths referenced in the codebase map exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JyPYTnfrcQbhgG76Z7bKYm

---
_Generated by [Claude Code](https://claude.ai/code/session_01JyPYTnfrcQbhgG76Z7bKYm)_