### PR TITLE
fixed small display innacuracy with config values below threhold

### DIFF
--- a/src/frontend/insert/input-parser.ts
+++ b/src/frontend/insert/input-parser.ts
@@ -672,7 +672,7 @@ function formatExpression(
         return {
             hasError: true,
             expression,
-            errorMessage: `Value must be greater than ${formatValueWithUnits(
+            errorMessage: `Value must be greater than or equal to ${formatValueWithUnits(
                 options.min,
                 options.displayUnit,
                 options.displayPrecision
@@ -682,7 +682,7 @@ function formatExpression(
         return {
             hasError: true,
             expression,
-            errorMessage: `Value must be less than ${formatValueWithUnits(
+            errorMessage: `Value must be less than or equal to ${formatValueWithUnits(
                 options.max,
                 options.displayUnit,
                 options.displayPrecision


### PR DESCRIPTION
Prevously, entering a number less than 0 into a config field would result in a message stating that the value had to be greater than 0. Now, it says the value has to be greater than or equal to 0 to accuratley reflect the tolerance.