### PR TITLE
Comment out unsupported wrangler limits blocks that broke cert deploy

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -116,10 +116,12 @@
             "vars": {
                 "ADMIN_TEAM": "6a62e6efcc21741bea57362c",
                 "NODE_ENV": "development"
-            },
-            "limits": {
-                "subrequests": 500000
             }
+            // Requires the Standard Usage Model; rejected on the Free plan
+            // (error 100328). Re-enable once on a paid plan.
+            // "limits": {
+            //     "subrequests": 500000
+            // }
         },
         "production": {
             "d1_databases": [
@@ -157,10 +159,12 @@
             "vars": {
                 "ADMIN_TEAM": "5b620150b2190f0fca90ec10",
                 "NODE_ENV": "production"
-            },
-            "limits": {
-                "subrequests": 500000
             }
+            // Requires the Standard Usage Model; rejected on the Free plan
+            // (error 100328). Re-enable once on a paid plan.
+            // "limits": {
+            //     "subrequests": 500000
+            // }
         }
     }
 }


### PR DESCRIPTION
PR #37 added `limits: { subrequests: 500000 }` to the cert and production
environments. Wrangler limits are only supported on the Standard Usage Model;
on this Free-plan account the deploy is rejected at the versions endpoint with
Cloudflare error 100328 ("CPU limits are not supported for the Free plan"), so
the post-merge cert deploy failed even though CI (type-check/lint/test) passed.

Comment out both limits blocks to restore deploys, keeping them documented so
they can be re-enabled after moving to a paid plan.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BSxhQes1omyhxKXe9uHY4K